### PR TITLE
fix: add safe.directory config for Git 2.35.2+ in Docker containers

### DIFF
--- a/mirror.sh
+++ b/mirror.sh
@@ -3,6 +3,8 @@ set -eu
 
 /setup-ssh.sh
 
+git config --global --add safe.directory /github/workspace
+
 export GIT_SSH_COMMAND="ssh -v -i ~/.ssh/id_rsa -o StrictHostKeyChecking=no -l $INPUT_SSH_USERNAME"
 git remote add codecommit "$INPUT_TARGET_REPO_URL"
 


### PR DESCRIPTION
Newer Git versions reject operations on directories owned by a different user. This fails inside Docker containers where the workspace is mounted from the runner. Adding /github/workspace as a safe directory resolves the 'dubious ownership' error.